### PR TITLE
make expiryDate on login response object optional

### DIFF
--- a/Meteor/METDDPClient.m
+++ b/Meteor/METDDPClient.m
@@ -650,7 +650,8 @@ NSString * const METDDPClientDidChangeAccountNotification = @"METDDPClientDidCha
     NSString *resumeToken = result[@"token"];
     NSDate *expiryDate = result[@"tokenExpires"];
     
-    if (userID && resumeToken && expiryDate) {
+    // verify login method result includes userID and resumeToken. expiryDate is optional.
+    if (userID && resumeToken) {
       METAccount *account = [[METAccount alloc] initWithUserID:userID resumeToken:resumeToken expiryDate:expiryDate];
       return account;
     }

--- a/Tests/UnitTests/METDDPClientAccountsTests.m
+++ b/Tests/UnitTests/METDDPClientAccountsTests.m
@@ -67,6 +67,25 @@
   XCTAssertEqualObjects(@"lovelace", _client.account.userID);
 }
 
+- (void)testSuccessfullyLoggingInWithoutExpiryDate {
+  XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler invoked"];
+  [_client loginWithMethodName:@"login" parameters:nil completionHandler:^(NSError *error) {
+    XCTAssertNil(error);
+    [expectation fulfill];
+  }];
+  
+  XCTAssertTrue(_client.loggingIn);
+  
+  NSString *lastMethodID = [self lastMethodID];
+  [_connection receiveMessage:@{@"msg": @"updated", @"methods": @[lastMethodID]}];
+  [_connection receiveMessage:@{@"msg": @"result", @"id": lastMethodID, @"result": @{@"id": @"lovelace", @"token": @"foo"}}];
+  
+  [self waitForExpectationsWithTimeout:1.0 handler:nil];
+  
+  XCTAssertFalse(_client.loggingIn);
+  XCTAssertEqualObjects(@"lovelace", _client.account.userID);
+}
+
 - (void)testUnsuccessfullyLoggingIn {
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler invoked"];
   [_client loginWithMethodName:@"login" parameters:nil completionHandler:^(NSError *error) {


### PR DESCRIPTION
In our application we have some custom login methods that do not return an expiryDate. Since this is not required by meteor, I am making it optional on the login response body