### PR TITLE
Expose ability to login with custom method + examine response object

### DIFF
--- a/Meteor/METDDPClient+AccountsPassword.m
+++ b/Meteor/METDDPClient+AccountsPassword.m
@@ -19,18 +19,25 @@
 // THE SOFTWARE.
 
 #import "METDDPClient+AccountsPassword.h"
-#import "METDDPClient_Internal.h"
 
 #import "NSString+METAdditions.h"
 
 @implementation METDDPClient (AccountsPassword)
 
 - (void)loginWithEmail:(NSString *)email password:(NSString *)password completionHandler:(METLogInCompletionHandler)completionHandler {
-  [self loginWithMethodName:@"login" parameters:@[@{@"user": @{@"email": email}, @"password": @{@"digest": [password SHA256String], @"algorithm": @"sha-256"}}] completionHandler:completionHandler];
+  [self loginWithMethodName:@"login" parameters:@[@{@"user": @{@"email": email}, @"password": @{@"digest": [password SHA256String], @"algorithm": @"sha-256"}}] completionHandler:^(id result, NSError *error) {
+    if (completionHandler) {
+      completionHandler(error);
+    }
+  }];
 }
 
 - (void)signUpWithEmail:(NSString *)email password:(NSString *)password completionHandler:(METLogInCompletionHandler)completionHandler {
-  [self loginWithMethodName:@"createUser" parameters:@[@{@"email": email, @"password": @{@"digest": [password SHA256String], @"algorithm": @"sha-256"}}] completionHandler:completionHandler];
+  [self loginWithMethodName:@"createUser" parameters:@[@{@"email": email, @"password": @{@"digest": [password SHA256String], @"algorithm": @"sha-256"}}] completionHandler:^(id result, NSError *error){
+    if (completionHandler) {
+      completionHandler(error);
+    }
+  }];
 }
 
 @end

--- a/Meteor/METDDPClient.h
+++ b/Meteor/METDDPClient.h
@@ -78,6 +78,7 @@ typedef void (^METLogOutCompletionHandler)(NSError *error);
 @property (assign, nonatomic, readonly, getter=isLoggingIn) BOOL loggingIn;
 @property (copy, nonatomic, readonly) NSString *userID;
 
+- (void)loginWithMethodName:(NSString *)methodName parameters:(NSArray *)parameters completionHandler:(METMethodCompletionHandler)completionHandler;
 - (void)logoutWithCompletionHandler:(METLogOutCompletionHandler)completionHandler;
 
 @end

--- a/Meteor/METDDPClient.m
+++ b/Meteor/METDDPClient.m
@@ -622,7 +622,7 @@ NSString * const METDDPClientDidChangeAccountNotification = @"METDDPClientDidCha
   return _account.userID;
 }
 
-- (void)loginWithMethodName:(NSString *)methodName parameters:(NSArray *)parameters completionHandler:(METLogInCompletionHandler)completionHandler {
+- (void)loginWithMethodName:(NSString *)methodName parameters:(NSArray *)parameters completionHandler:(METMethodCompletionHandler)completionHandler {
   self.loggingIn = YES;
   __block BOOL reconnected = NO;
   __weak METDDPClient *weakSelf = self;
@@ -639,7 +639,7 @@ NSString * const METDDPClientDidChangeAccountNotification = @"METDDPClientDidCha
     self.loggingIn = NO;
     self.account = [self accountFromLoginMethodResult:result];
     if (completionHandler) {
-      completionHandler(error);
+      completionHandler(result, error);
     }
   }];
 }
@@ -658,7 +658,7 @@ NSString * const METDDPClientDidChangeAccountNotification = @"METDDPClientDidCha
   return nil;
 }
 
-- (void)loginWithResumeToken:(NSString *)resumeToken completionHandler:(METLogInCompletionHandler)completionHandler {
+- (void)loginWithResumeToken:(NSString *)resumeToken completionHandler:(METMethodCompletionHandler)completionHandler {
   [self loginWithMethodName:@"login" parameters:@[@{@"resume": resumeToken}] completionHandler:completionHandler];
 }
 

--- a/Meteor/METDDPClient_Internal.h
+++ b/Meteor/METDDPClient_Internal.h
@@ -63,8 +63,6 @@ typedef NS_OPTIONS(NSInteger, METMethodCallOptions) {
 @property(strong, nonatomic, readonly) METMethodInvocationContext *currentMethodInvocationContext;
 - (void)sendMethodMessageForMethodInvocation:(METMethodInvocation *)methodInvocation;
 
-- (void)loginWithMethodName:(NSString *)methodName parameters:(NSArray *)parameters completionHandler:(METLogInCompletionHandler)completionHandler;
-
 - (NSArray *)convertParameters:(NSArray *)parameters;
 
 @end

--- a/Tests/UnitTests/METDDPClientAccountsTests.m
+++ b/Tests/UnitTests/METDDPClientAccountsTests.m
@@ -50,7 +50,7 @@
 
 - (void)testSuccessfullyLoggingIn {
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler invoked"];
-  [_client loginWithMethodName:@"login" parameters:nil completionHandler:^(NSError *error) {
+  [_client loginWithMethodName:@"login" parameters:nil completionHandler:^(id result, NSError *error) {
     XCTAssertNil(error);
     [expectation fulfill];
   }];
@@ -69,7 +69,7 @@
 
 - (void)testUnsuccessfullyLoggingIn {
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler invoked"];
-  [_client loginWithMethodName:@"login" parameters:nil completionHandler:^(NSError *error) {
+  [_client loginWithMethodName:@"login" parameters:nil completionHandler:^(id result, NSError *error) {
     XCTAssertEqualObjects(error.domain, METDDPErrorDomain);
     XCTAssertEqual(error.code, METDDPServerError);
     [expectation fulfill];
@@ -221,7 +221,7 @@
 
 - (void)testInvokesCompletionHandlerWithMostRecentAccountWhenReconnectingWhenResultReceivedButNotUpdatesDone {
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler invoked"];
-  [_client loginWithMethodName:@"login" parameters:@[] completionHandler:^(NSError *error) {
+  [_client loginWithMethodName:@"login" parameters:@[] completionHandler:^(id result, NSError *error) {
     XCTAssertEqualObjects(@"turing", _client.account.userID);
     [expectation fulfill];
   }];


### PR DESCRIPTION
Expose loginWithMethodName:parameters:completionHandler: in METDDPClient.h. Use METMethodCompletionHandler instead of METLogInCompletionHandler to expose the login response body.

Not sure if this is the right way to go about it but figured i'd send a PR to start a discussion on how to achieve the following:

It is helpful to us to be able to see the login response object as it contains some valuable tracking information (ie whether a new account was created.) in addition to the login tokens/userId.

We have a custom login method that accepts a facebook auth token directly and returns the users meteor credentials.  Details on this type of custom login can be seen in our response to the following stack overflow issue [here](http://stackoverflow.com/questions/18118503/how-can-i-login-to-meteor-with-native-device-facebook)

This PR is what I'm working with now to achieve this. Any feedback on how to expose this power more cleanly from meteor-ios is welcomed. 