### PR TITLE
add ability to include first/last name on signup

### DIFF
--- a/Meteor/METDDPClient+AccountsPassword.h
+++ b/Meteor/METDDPClient+AccountsPassword.h
@@ -30,4 +30,6 @@
 
 - (void)signUpWithEmail:(NSString *)email password:(NSString *)password firstName:(NSString *)firstName lastName:(NSString *)lastName completionHandler:(METLogInCompletionHandler)completionHandler;
 
+- (void)signUpWithEmail:(NSString *)email password:(NSString *)password profile:(NSDictionary *)profile completionHandler:(METLogInCompletionHandler)completionHandler;
+
 @end

--- a/Meteor/METDDPClient+AccountsPassword.h
+++ b/Meteor/METDDPClient+AccountsPassword.h
@@ -28,4 +28,6 @@
 
 - (void)signUpWithEmail:(NSString *)email password:(NSString *)password completionHandler:(METLogInCompletionHandler)completionHandler;
 
+- (void)signUpWithEmail:(NSString *)email password:(NSString *)password firstName:(NSString *)firstName lastName:(NSString *)lastName completionHandler:(METLogInCompletionHandler)completionHandler;
+
 @end

--- a/Meteor/METDDPClient+AccountsPassword.m
+++ b/Meteor/METDDPClient+AccountsPassword.m
@@ -30,27 +30,23 @@
 }
 
 - (void)signUpWithEmail:(NSString *)email password:(NSString *)password completionHandler:(METLogInCompletionHandler)completionHandler {
-  [self loginWithMethodName:@"createUser" parameters:@[[self parametersForCreateUserMethodFromEmail:email password:password]] completionHandler:completionHandler];
+  [self signUpWithEmail:email password:password profile:nil completionHandler:completionHandler];
 }
 
 - (void)signUpWithEmail:(NSString *)email password:(NSString *)password firstName:(NSString *)firstName lastName:(NSString *)lastName completionHandler:(METLogInCompletionHandler)completionHandler {
-  NSMutableDictionary *profileObject = [NSMutableDictionary dictionary];
-  firstName ? profileObject[@"first_name"] = firstName : nil;
-  lastName ? profileObject[@"last_name"] = lastName : nil;
+  NSMutableDictionary *profile = [NSMutableDictionary dictionary];
+  firstName ? profile[@"first_name"] = firstName : nil;
+  lastName ? profile[@"last_name"] = lastName : nil;
   
-  [self signUpWithEmail:email password:password profile:profileObject completionHandler:completionHandler];
+  [self signUpWithEmail:email password:password profile:profile completionHandler:completionHandler];
 }
 
 - (void)signUpWithEmail:(NSString *)email password:(NSString *)password profile:(NSDictionary *)profile completionHandler:(METLogInCompletionHandler)completionHandler {
-  [self loginWithMethodName:@"createUser" parameters:@[[self parametersForCreateUserMethodFromEmail:email password:password profile:profile]] completionHandler:completionHandler];
+  NSArray *parameters = @[[self parametersForCreateUserMethodFromEmail:email password:password profile:profile]];
+  [self loginWithMethodName:@"createUser" parameters:parameters completionHandler:completionHandler];
 }
 
 #pragma mark - Helper Methods
-
-- (NSDictionary *)parametersForCreateUserMethodFromEmail:(NSString *)email password:(NSString *)password
-{
-  return [self parametersForCreateUserMethodFromEmail:email password:password profile:nil];
-}
 
 - (NSDictionary *)parametersForCreateUserMethodFromEmail:(NSString *)email password:(NSString *)password profile:(NSDictionary *)profile {
   // build the base parameters body with email/password

--- a/Meteor/METDDPClient+AccountsPassword.m
+++ b/Meteor/METDDPClient+AccountsPassword.m
@@ -34,28 +34,32 @@
 }
 
 - (void)signUpWithEmail:(NSString *)email password:(NSString *)password firstName:(NSString *)firstName lastName:(NSString *)lastName completionHandler:(METLogInCompletionHandler)completionHandler {
-  [self loginWithMethodName:@"createUser" parameters:@[[self parametersForCreateUserMethodFromEmail:email password:password firstName:firstName lastName:lastName]] completionHandler:completionHandler];
+  NSMutableDictionary *profileObject = [NSMutableDictionary dictionary];
+  firstName ? profileObject[@"first_name"] = firstName : nil;
+  lastName ? profileObject[@"last_name"] = lastName : nil;
+  
+  [self signUpWithEmail:email password:password profile:profileObject completionHandler:completionHandler];
+}
+
+- (void)signUpWithEmail:(NSString *)email password:(NSString *)password profile:(NSDictionary *)profile completionHandler:(METLogInCompletionHandler)completionHandler {
+  [self loginWithMethodName:@"createUser" parameters:@[[self parametersForCreateUserMethodFromEmail:email password:password profile:profile]] completionHandler:completionHandler];
 }
 
 #pragma mark - Helper Methods
 
 - (NSDictionary *)parametersForCreateUserMethodFromEmail:(NSString *)email password:(NSString *)password
 {
-  return [self parametersForCreateUserMethodFromEmail:email password:password firstName:nil lastName:nil];
+  return [self parametersForCreateUserMethodFromEmail:email password:password profile:nil];
 }
 
-- (NSDictionary *)parametersForCreateUserMethodFromEmail:(NSString *)email password:(NSString *)password firstName:(NSString *)firstName lastName:(NSString *)lastName {
+- (NSDictionary *)parametersForCreateUserMethodFromEmail:(NSString *)email password:(NSString *)password profile:(NSDictionary *)profile {
   // build the base parameters body with email/password
   NSDictionary *params =  @{@"email": email, @"password": @{@"digest": [password SHA256String], @"algorithm": @"sha-256"}};
   
-  // if we have a firstName or last name, include it include the `profile` object
-  if (firstName || lastName) {
-    NSMutableDictionary *profileParams = [NSMutableDictionary dictionary];
-    firstName ? profileParams[@"first_name"] = firstName : nil;
-    lastName ? profileParams[@"last_name"] = lastName : nil;
-    
+  // if we have a profile object, include it include under the key `profile`
+  if (profile) {
     NSMutableDictionary *mutableParams = [params mutableCopy];
-    mutableParams[@"profile"] = profileParams;
+    mutableParams[@"profile"] = profile;
     params = mutableParams;
   }
   

--- a/Meteor/METDDPClient+AccountsPassword.m
+++ b/Meteor/METDDPClient+AccountsPassword.m
@@ -30,7 +30,39 @@
 }
 
 - (void)signUpWithEmail:(NSString *)email password:(NSString *)password completionHandler:(METLogInCompletionHandler)completionHandler {
-  [self loginWithMethodName:@"createUser" parameters:@[@{@"email": email, @"password": @{@"digest": [password SHA256String], @"algorithm": @"sha-256"}}] completionHandler:completionHandler];
+  [self loginWithMethodName:@"createUser" parameters:@[[self createUserParametersObjectWithEmail:email password:password]] completionHandler:completionHandler];
+}
+
+- (void)signUpWithEmail:(NSString *)email password:(NSString *)password firstName:(NSString *)firstName lastName:(NSString *)lastName completionHandler:(METLogInCompletionHandler)completionHandler {
+  [self loginWithMethodName:@"createUser" parameters:@[[self createUserParametersObjectWithEmail:email password:password firstName:firstName lastName:lastName]] completionHandler:completionHandler];
+}
+
+- (NSDictionary *)createUserParametersObjectWithEmail:(NSString *)email password:(NSString *)password
+{
+  return [self createUserParametersObjectWithEmail:email password:password firstName:nil lastName:nil];
+}
+
+- (NSDictionary *)createUserParametersObjectWithEmail:(NSString *)email password:(NSString *)password firstName:(NSString *)firstName lastName:(NSString *)lastName {
+  NSDictionary *params =  @{
+                            @"email": email,
+                            @"password": @{@"digest": [password SHA256String], @"algorithm": @"sha-256"}
+                            };
+  
+  if (firstName || lastName) {
+    NSMutableDictionary *profileParams = [NSMutableDictionary dictionary];
+    if (firstName) {
+      profileParams[@"first_name"] = firstName;
+    }
+    if (lastName) {
+      profileParams[@"last_name"] = lastName;
+    }
+    
+    NSMutableDictionary *mutableParams = [params mutableCopy];
+    mutableParams[@"profile"] = profileParams;
+    params = mutableParams;
+  }
+  
+  return params;
 }
 
 @end

--- a/Meteor/METDDPClient+AccountsPassword.m
+++ b/Meteor/METDDPClient+AccountsPassword.m
@@ -30,32 +30,29 @@
 }
 
 - (void)signUpWithEmail:(NSString *)email password:(NSString *)password completionHandler:(METLogInCompletionHandler)completionHandler {
-  [self loginWithMethodName:@"createUser" parameters:@[[self createUserParametersObjectWithEmail:email password:password]] completionHandler:completionHandler];
+  [self loginWithMethodName:@"createUser" parameters:@[[self parametersForCreateUserMethodFromEmail:email password:password]] completionHandler:completionHandler];
 }
 
 - (void)signUpWithEmail:(NSString *)email password:(NSString *)password firstName:(NSString *)firstName lastName:(NSString *)lastName completionHandler:(METLogInCompletionHandler)completionHandler {
-  [self loginWithMethodName:@"createUser" parameters:@[[self createUserParametersObjectWithEmail:email password:password firstName:firstName lastName:lastName]] completionHandler:completionHandler];
+  [self loginWithMethodName:@"createUser" parameters:@[[self parametersForCreateUserMethodFromEmail:email password:password firstName:firstName lastName:lastName]] completionHandler:completionHandler];
 }
 
-- (NSDictionary *)createUserParametersObjectWithEmail:(NSString *)email password:(NSString *)password
+#pragma mark - Helper Methods
+
+- (NSDictionary *)parametersForCreateUserMethodFromEmail:(NSString *)email password:(NSString *)password
 {
-  return [self createUserParametersObjectWithEmail:email password:password firstName:nil lastName:nil];
+  return [self parametersForCreateUserMethodFromEmail:email password:password firstName:nil lastName:nil];
 }
 
-- (NSDictionary *)createUserParametersObjectWithEmail:(NSString *)email password:(NSString *)password firstName:(NSString *)firstName lastName:(NSString *)lastName {
-  NSDictionary *params =  @{
-                            @"email": email,
-                            @"password": @{@"digest": [password SHA256String], @"algorithm": @"sha-256"}
-                            };
+- (NSDictionary *)parametersForCreateUserMethodFromEmail:(NSString *)email password:(NSString *)password firstName:(NSString *)firstName lastName:(NSString *)lastName {
+  // build the base parameters body with email/password
+  NSDictionary *params =  @{@"email": email, @"password": @{@"digest": [password SHA256String], @"algorithm": @"sha-256"}};
   
+  // if we have a firstName or last name, include it include the `profile` object
   if (firstName || lastName) {
     NSMutableDictionary *profileParams = [NSMutableDictionary dictionary];
-    if (firstName) {
-      profileParams[@"first_name"] = firstName;
-    }
-    if (lastName) {
-      profileParams[@"last_name"] = lastName;
-    }
+    firstName ? profileParams[@"first_name"] = firstName : nil;
+    lastName ? profileParams[@"last_name"] = lastName : nil;
     
     NSMutableDictionary *mutableParams = [params mutableCopy];
     mutableParams[@"profile"] = profileParams;


### PR DESCRIPTION
Adding a new method exposed in `METDDPClient+AccountsPassword.h` category that allows signup to include first/last name in addition to email/password.