### PR TITLE
remove subscriptions sync if timeout is zero, to preserve add/remove call order

### DIFF
--- a/Tests/UnitTests/METSubscriptionManagerTests.m
+++ b/Tests/UnitTests/METSubscriptionManagerTests.m
@@ -235,4 +235,14 @@
   XCTAssertEqual(subscription1, subscription2);
 }
 
+- (void)testSubscriptionRemovedImmediatelyWhenSubHasNotInUseTimeoutOfZero {
+  _subscriptionManager.defaultNotInUseTimeout = 0;
+  
+  METSubscription *subscription1 = [_subscriptionManager addSubscriptionWithName:@"todos" parameters:@[@"bla"] completionHandler:nil];
+  [_subscriptionManager removeSubscription:subscription1];
+  METSubscription *subscription2 = [_subscriptionManager addSubscriptionWithName:@"todos" parameters:@[@"bla"] completionHandler:nil];
+  
+  XCTAssertNotEqual(subscription1, subscription2);
+}
+
 @end


### PR DESCRIPTION
We have a few features that require `unsub` messages to be sent over the wire before `sub` message to the same subscription, with different parameters.  Even with a timeout of zero, in the current code on master branch, the `unsub` would go after the `sub`.  

This is caused by the following:

```objectivec
METSubscription *subscription1 = [_subscriptionManager addSubscriptionWithName:@"todos" parameters:@[@"bla"] completionHandler:nil];

// later ...

[_subscriptionManager removeSubscription:subscription1];
METSubscription *subscription2 = [_subscriptionManager addSubscriptionWithName:@"todos" parameters:@[@"XXXXXXXX"] completionHandler:nil];
```

if the `METSubscriptionManager` was configured with a default timeout of 0, or the `METSubscription` had a timeout configured of zero, the call to `removeSubscription` would actually cause the remove to happen after `[subscription.reuseTimer startWithTimeInterval:subscription.notInUseTimeout];`. Even with timeout 0 the `sub` for subscription 2 would happen first. 