### PR TITLE
Fix for mixed case collection names mapping to Core Data entities

### DIFF
--- a/Meteor/METIncrementalStore.m
+++ b/Meteor/METIncrementalStore.m
@@ -398,7 +398,7 @@ NSString * const METIncrementalStoreObjectsDidChangeNotification = @"METIncremen
   
   for (NSEntityDescription *entity in entities) {
     NSString *entityName = entity.name;
-    NSString *collectionName = entity.userInfo[@"collectionName"] ?: [[entityName pluralizedString] lowercaseString];
+    NSString *collectionName = entity.userInfo[@"collectionName"] ?: [[entityName pluralizedString] stringByReplacingCharactersInRange:NSMakeRange(0, 1) withString:[[entityName lowercaseString] substringToIndex:1]];
 
     _entityNamesByCollectionName[collectionName] = entityName;
     _collectionNamesByEntityName[entityName] = collectionName;


### PR DESCRIPTION
Small fix for an issue I had with a mixed case collection name not mapping to the Core Data entity name - now the default mapping just lowercases the first letter of the entity name instead of the entire name.