### PR TITLE
Todos example is crashing in Xcode 7.2

### DIFF
--- a/Examples/Todos/Todos/List.swift
+++ b/Examples/Todos/Todos/List.swift
@@ -22,7 +22,7 @@ import CoreData
 
 class List: NSManagedObject {
   @NSManaged var name: String!
-  @NSManaged var incompleteCount: Int
+  @NSManaged var incompleteCount: Int64
 
   @NSManaged var todos: NSSet!
   


### PR DESCRIPTION
Message: CoreData: error: Property 'incompleteCount' is a scalar type on class 'Todos.List' that does not match its Entity's property's scalar type.  Dynamically generated accessors do not support implicit type coercion.  Cannot generate a getter method for it.

Fix: changed type of incompleteCount to Int64