### PR TITLE
Added overload to unsubscribe from a collection immediately

### DIFF
--- a/Meteor/METDDPClient.h
+++ b/Meteor/METDDPClient.h
@@ -95,6 +95,7 @@ typedef void (^METLogOutCompletionHandler)(NSError * __nullable error);
 - (METSubscription *)addSubscriptionWithName:(NSString *)name parameters:(nullable NSArray *)parameters;
 - (METSubscription *)addSubscriptionWithName:(NSString *)name parameters:(nullable NSArray *)parameters completionHandler:(nullable METSubscriptionCompletionHandler)completionHandler;
 - (void)removeSubscription:(METSubscription *)subscription;
+- (void)removeSubscription:(METSubscription *)subscription immediately:(BOOL)immediately completionHandler:(nullable METSubscriptionCompletionHandler)completionHandler;
 
 #pragma mark - Method Invocations
 /// @name Defining Method Stubs

--- a/Meteor/METDDPClient.m
+++ b/Meteor/METDDPClient.m
@@ -520,7 +520,11 @@ NSString * const METDDPClientDidChangeAccountNotification = @"METDDPClientDidCha
 }
 
 - (void)removeSubscription:(METSubscription *)subscription {
-  [_subscriptionManager removeSubscription:subscription];
+    [self removeSubscription:subscription immediately:NO completionHandler:nil];
+}
+
+- (void)removeSubscription:(METSubscription *)subscription immediately:(BOOL)immediately completionHandler:(nullable METSubscriptionCompletionHandler)completionHandler {
+  [_subscriptionManager removeSubscription:subscription immediately:immediately completionHandler:completionHandler];
 }
 
 - (void)sendUnsubMessageForSubscription:(METSubscription *)subscription {

--- a/Meteor/METSubscriptionManager.h
+++ b/Meteor/METSubscriptionManager.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) NSTimeInterval defaultNotInUseTimeout;
 
 - (METSubscription *)addSubscriptionWithName:(NSString *)name parameters:(nullable NSArray *)parameters completionHandler:(nullable METSubscriptionCompletionHandler)completionHandler;
-- (void)removeSubscription:(METSubscription *)subscription;
+- (void)removeSubscription:(METSubscription *)subscription immediately:(BOOL)immediately completionHandler:(nullable METSubscriptionCompletionHandler)completionHandler;
 
 - (void)didReceiveReadyForSubscriptionWithID:(NSString *)subscriptionID;
 - (void)didReceiveNosubForSubscriptionWithID:(NSString *)subscriptionID error:(NSError *)error;


### PR DESCRIPTION
I'm storing an array of values (groupIds) in the user-profile. When this array changes, another collection needs to be unsubscribed und subscribed again (since publish with relations isn't supported without using 3rd party packages), because the value array is used in the publish-function. 